### PR TITLE
chore: bump module path from v3 to v4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/revittco/fsa/v3
+module github.com/revittco/fsa/v4
 
 go 1.26
 


### PR DESCRIPTION
## Summary

- Update Go module path from `github.com/revittco/fsa/v3` to `github.com/revittco/fsa/v4` in preparation for the v4.0.0 release
- Required because PR #23 introduced breaking changes (GET→POST for login/confirm, cookie-based refresh tokens)

## Test plan

- [x] `go test ./...` passes (62 tests)
- [ ] Merge this PR, then tag and release v4.0.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)